### PR TITLE
Some mkldscript improvements

### DIFF
--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -336,17 +336,21 @@ static void write_rom_script(const char *dir, const char *fname, const struct Se
         );
 
         /* placement */
-        fprintf(f, "\t..%s ", seg->name);
+        fprintf(f, "\t_%sSegmentStart = ", seg->name);
         if (seg->fields & (1 << STMT_after))
-            fprintf(f, "_%sSegmentEnd ", seg->after);
+            fprintf(f, "_%sSegmentEnd", seg->after);
         else if (seg->fields & (1 << STMT_number))
-            fprintf(f, "0x%02X000000 ", seg->number);
+            fprintf(f, "0x%02X000000", seg->number);
         else if (seg->fields & (1 << STMT_address))
-            fprintf(f, "0x%08X ", seg->address);
-        fprintf(f, ": AT(_%sSegmentRomStart)\n\t{\n", seg->name);
+            fprintf(f, "0x%08X", seg->address);
+        else
+            fprintf(f, ".");
+        fprintf(f, ";\n\n");
+
+        fprintf(f, "\t..%s _%sSegmentStart : AT(_%sSegmentRomStart)\n\t{\n",
+                seg->name, seg->name, seg->name);
     
         /* content sections */
-        fprintf(f, "\t\t_%sSegmentStart = .;\n\n", seg->name);
         fprintf(f, "\t\t%s/%s.o (.text)\n", dir, seg->name);
         fprintf(f, "\t\t%s/%s.o (.data)\n", dir, seg->name);
         fprintf(f, "\t\t%s/%s.o (.rodata)\n", dir, seg->name);
@@ -397,8 +401,9 @@ static void write_rom_script(const char *dir, const char *fname, const struct Se
 
         /* end segment */
         fprintf(f,
-            "\t\t_%sSegmentEnd = .;\n"
-            "\t\t_%sSegmentSize = ABSOLUTE(_%sSegmentEnd - _%sSegmentStart);\n"
+            "\n"
+            "\t_%sSegmentEnd = .;\n"
+            "\t_%sSegmentSize = ABSOLUTE(_%sSegmentEnd - _%sSegmentStart);\n"
             "\n\n",
             seg->name,
             seg->name, seg->name, seg->name

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -417,7 +417,10 @@ static void usage(const char *execname)
         "Ocarina of Time linker script generator\n"
         "usage:\n"
         "\t%s -s <spec-file> <segment-dir> <segment-name>\n"
-        "\t%s -r <spec-file> <segment-dir> <output-file>\n",
+        "\t\tWrite a linker script and dependencies for the specified segment\n"
+        "\t\n"
+        "\t%s -r <spec-file> <segment-dir> <output-file>\n"
+        "\t\tWrite a linker script for linking all the segments together\n",
         execname,
         execname
     );

--- a/tools/mkldscript.c
+++ b/tools/mkldscript.c
@@ -376,6 +376,7 @@ static void write_rom_script(const char *dir, const char *fname, const struct Se
 
         fprintf(f,
             "\t}\n"
+            "\n"
             "\t_%sSegmentRomSize = ABSOLUTE(_%sSegment%sEnd - _%sSegmentTextStart);\n"
             "\t_RomSize += _%sSegmentRomSize;\n"
             "\t_%sSegmentRomEndTemp = _RomSize;\n"
@@ -391,6 +392,7 @@ static void write_rom_script(const char *dir, const char *fname, const struct Se
 
         /* .bss sections */
         fprintf(f,
+            "\n"
             "\t..%s.bss (NOLOAD) :\n"
             "\t{\n"
             "\t\t%s/%s.o (.bss)\n"


### PR DESCRIPTION
Implementation of some of the things I suggested in my review in https://github.com/zeldaret/oot/pull/1204

Apart from the usage sentences, this changes the build/ldscript.txt from (excerpt)

<details>

```
	_buffersSegmentRomStartTemp = _RomSize;
	_buffersSegmentRomStart = _buffersSegmentRomStartTemp;
	..buffers : AT(_buffersSegmentRomStart)
	{
		_buffersSegmentStart = .;

		build/segments/buffers.o (.text)
		build/segments/buffers.o (.data)
		build/segments/buffers.o (.rodata)
		_buffersSegmentOvlStart = .;
		_buffersSegmentOvlEnd = .;
		_buffersSegmentOvlSize = ABSOLUTE(_buffersSegmentOvlEnd - _buffersSegmentOvlStart);
	}
	_buffersSegmentRomSize = ABSOLUTE(_buffersSegmentOvlEnd - _buffersSegmentTextStart);
	_RomSize += _buffersSegmentRomSize;
	_buffersSegmentRomEndTemp = _RomSize;
	_buffersSegmentRomEnd = _buffersSegmentRomEndTemp;
	..buffers.bss (NOLOAD) :
	{
		build/segments/buffers.o (.bss)
	}
		_buffersSegmentEnd = .;
		_buffersSegmentSize = ABSOLUTE(_buffersSegmentEnd - _buffersSegmentStart);


	_ovl_titleSegmentRomStartTemp = _RomSize;
	_ovl_titleSegmentRomStart = _ovl_titleSegmentRomStartTemp;
	..ovl_title 0x80800000 : AT(_ovl_titleSegmentRomStart)
	{
		_ovl_titleSegmentStart = .;

		build/segments/ovl_title.o (.text)
		build/segments/ovl_title.o (.data)
		build/segments/ovl_title.o (.rodata)
		_ovl_titleSegmentOvlStart = .;
		build/segments/ovl_title.reloc.o (.ovl)
		_ovl_titleSegmentOvlEnd = .;
		_ovl_titleSegmentOvlSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentOvlStart);
	}
	_ovl_titleSegmentRomSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentTextStart);
	_RomSize += _ovl_titleSegmentRomSize;
	_ovl_titleSegmentRomEndTemp = _RomSize;
	_ovl_titleSegmentRomEnd = _ovl_titleSegmentRomEndTemp;
	..ovl_title.bss (NOLOAD) :
	{
		build/segments/ovl_title.o (.bss)
	}
		_ovl_titleSegmentEnd = .;
		_ovl_titleSegmentSize = ABSOLUTE(_ovl_titleSegmentEnd - _ovl_titleSegmentStart);
```

</details>

to

<details>

```
	_buffersSegmentRomStartTemp = _RomSize;
	_buffersSegmentRomStart = _buffersSegmentRomStartTemp;
	_buffersSegmentStart = .;

	..buffers _buffersSegmentStart : AT(_buffersSegmentRomStart)
	{
		build/segments/buffers.o (.text)
		build/segments/buffers.o (.data)
		build/segments/buffers.o (.rodata)
	}

	_buffersSegmentRomSize = ABSOLUTE(_buffersSegmentRoDataEnd - _buffersSegmentTextStart);
	_RomSize += _buffersSegmentRomSize;
	_buffersSegmentRomEndTemp = _RomSize;
	_buffersSegmentRomEnd = _buffersSegmentRomEndTemp;

	..buffers.bss (NOLOAD) :
	{
		build/segments/buffers.o (.bss)
	}

	_buffersSegmentEnd = .;
	_buffersSegmentSize = ABSOLUTE(_buffersSegmentEnd - _buffersSegmentStart);


	_ovl_titleSegmentRomStartTemp = _RomSize;
	_ovl_titleSegmentRomStart = _ovl_titleSegmentRomStartTemp;
	_ovl_titleSegmentStart = 0x80800000;

	..ovl_title _ovl_titleSegmentStart : AT(_ovl_titleSegmentRomStart)
	{
		build/segments/ovl_title.o (.text)
		build/segments/ovl_title.o (.data)
		build/segments/ovl_title.o (.rodata)

		_ovl_titleSegmentOvlStart = .;
		build/segments/ovl_title.reloc.o (.ovl)
		_ovl_titleSegmentOvlEnd = .;
		_ovl_titleSegmentOvlSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentOvlStart);
	}

	_ovl_titleSegmentRomSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentTextStart);
	_RomSize += _ovl_titleSegmentRomSize;
	_ovl_titleSegmentRomEndTemp = _RomSize;
	_ovl_titleSegmentRomEnd = _ovl_titleSegmentRomEndTemp;

	..ovl_title.bss (NOLOAD) :
	{
		build/segments/ovl_title.o (.bss)
	}

	_ovl_titleSegmentEnd = .;
	_ovl_titleSegmentSize = ABSOLUTE(_ovl_titleSegmentEnd - _ovl_titleSegmentStart);
```

</details>

diff:

<details>

```diff
 	_buffersSegmentRomStartTemp = _RomSize;
 	_buffersSegmentRomStart = _buffersSegmentRomStartTemp;
-	..buffers : AT(_buffersSegmentRomStart)
-	{
-		_buffersSegmentStart = .;
+	_buffersSegmentStart = .;
 
+	..buffers _buffersSegmentStart : AT(_buffersSegmentRomStart)
+	{
 		build/segments/buffers.o (.text)
 		build/segments/buffers.o (.data)
 		build/segments/buffers.o (.rodata)
-		_buffersSegmentOvlStart = .;
-		_buffersSegmentOvlEnd = .;
-		_buffersSegmentOvlSize = ABSOLUTE(_buffersSegmentOvlEnd - _buffersSegmentOvlStart);
 	}
-	_buffersSegmentRomSize = ABSOLUTE(_buffersSegmentOvlEnd - _buffersSegmentTextStart);
+
+	_buffersSegmentRomSize = ABSOLUTE(_buffersSegmentRoDataEnd - _buffersSegmentTextStart);
 	_RomSize += _buffersSegmentRomSize;
 	_buffersSegmentRomEndTemp = _RomSize;
 	_buffersSegmentRomEnd = _buffersSegmentRomEndTemp;
+
 	..buffers.bss (NOLOAD) :
 	{
 		build/segments/buffers.o (.bss)
 	}
-		_buffersSegmentEnd = .;
-		_buffersSegmentSize = ABSOLUTE(_buffersSegmentEnd - _buffersSegmentStart);
+
+	_buffersSegmentEnd = .;
+	_buffersSegmentSize = ABSOLUTE(_buffersSegmentEnd - _buffersSegmentStart);
 
 
 	_ovl_titleSegmentRomStartTemp = _RomSize;
 	_ovl_titleSegmentRomStart = _ovl_titleSegmentRomStartTemp;
-	..ovl_title 0x80800000 : AT(_ovl_titleSegmentRomStart)
-	{
-		_ovl_titleSegmentStart = .;
+	_ovl_titleSegmentStart = 0x80800000;
 
+	..ovl_title _ovl_titleSegmentStart : AT(_ovl_titleSegmentRomStart)
+	{
 		build/segments/ovl_title.o (.text)
 		build/segments/ovl_title.o (.data)
 		build/segments/ovl_title.o (.rodata)
+
 		_ovl_titleSegmentOvlStart = .;
 		build/segments/ovl_title.reloc.o (.ovl)
 		_ovl_titleSegmentOvlEnd = .;
 		_ovl_titleSegmentOvlSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentOvlStart);
 	}
+
 	_ovl_titleSegmentRomSize = ABSOLUTE(_ovl_titleSegmentOvlEnd - _ovl_titleSegmentTextStart);
 	_RomSize += _ovl_titleSegmentRomSize;
 	_ovl_titleSegmentRomEndTemp = _RomSize;
 	_ovl_titleSegmentRomEnd = _ovl_titleSegmentRomEndTemp;
+
 	..ovl_title.bss (NOLOAD) :
 	{
 		build/segments/ovl_title.o (.bss)
 	}
-		_ovl_titleSegmentEnd = .;
-		_ovl_titleSegmentSize = ABSOLUTE(_ovl_titleSegmentEnd - _ovl_titleSegmentStart);
+
+	_ovl_titleSegmentEnd = .;
+	_ovl_titleSegmentSize = ABSOLUTE(_ovl_titleSegmentEnd - _ovl_titleSegmentStart);
```

</details>